### PR TITLE
TypeError: response.errors.forEach is not a function

### DIFF
--- a/onesignal/onesignal.js
+++ b/onesignal/onesignal.js
@@ -25,10 +25,16 @@ module.exports = function (RED) {
         res.on('data', function (data) {
           var response = JSON.parse(data);
           if (response.errors) {
-            response.errors.forEach(function (err) {
-              console.log("ONESIGNAL Responce Error:", err);
-              node.error("ONESIGNAL Responce Error", err);
-            })
+            if (Array.isArray(response.errors)) {
+              response.errors.forEach(function (err) {
+                console.log("ONESIGNAL Responce Error:", err);
+                node.error("ONESIGNAL Responce Error", err);
+              })
+            }
+            if (typeof response.errors === 'string' || response.errors instanceof String) {
+              console.log("ONESIGNAL Responce Error:", response.errors);
+              node.error("ONESIGNAL Responce Error", response.errors);
+            }
             node.status({ fill: "red", shape: "ring", text: "OneSignal ERROR" });
           } else {
             node.log("Notification SENT SUCCESSFULLY");


### PR DESCRIPTION
Node-RED crashes (and reboots) with the uncaught exception "TypeError: response.errors.forEach is not a function"
This happened when the notifications are sent using player ids to:
- an iPhone with disabled notifications for the app
- the XCode iOS Simulator
(i didn't try on the android simulator)